### PR TITLE
Issue #56: Add interactive verification tool for promise classifications

### DIFF
--- a/analysis/derived/verify_promises.py
+++ b/analysis/derived/verify_promises.py
@@ -1,0 +1,339 @@
+"""
+Interactive verification tool for LLM promise classifications.
+
+Presents each chat message with full group conversation context and current
+LLM-assigned label. Reviewer confirms or flips each label (0 = not promise,
+1 = promise). Progress saves automatically for pause/resume.
+
+Usage:
+    uv run python analysis/derived/verify_promises.py           # Start/resume review
+    uv run python analysis/derived/verify_promises.py --export  # Export without reviewing
+
+Author: Claude Code
+Date: 2026-04-10
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from experiment_data import load_experiment_data
+
+# FILE PATHS
+DATA_DIR = Path(__file__).parent.parent / 'datastore'
+RAW_DIR = DATA_DIR / 'raw'
+INPUT_FILE = DATA_DIR / 'derived' / 'promise_classifications.csv'
+PROGRESS_FILE = DATA_DIR / 'derived' / 'promise_verification_progress.json'
+OUTPUT_FILE = DATA_DIR / 'derived' / 'promise_classifications_verified.csv'
+
+
+# =====
+# Main function
+# =====
+def main():
+    """Main execution flow."""
+    args = parse_args()
+    df = pd.read_csv(INPUT_FILE)
+    review_items = build_review_items(df)
+    progress = load_progress()
+    remaining = print_status(review_items, progress)
+
+    if args.export or remaining == 0:
+        export_results(df, progress)
+        return
+
+    context_lookup = load_context()
+    progress = run_review(review_items, progress, context_lookup)
+    export_results(df, progress)
+
+
+def print_status(review_items: list, progress: dict) -> int:
+    """Print current review status and return remaining count."""
+    reviewed = sum(1 for r in review_items if r['key'] in progress)
+    remaining = len(review_items) - reviewed
+    print(f"\nLoaded {len(review_items)} messages ({reviewed} reviewed, {remaining} remaining)")
+    if remaining == 0:
+        print("All messages already reviewed!")
+    return remaining
+
+
+def load_context() -> dict:
+    """Load experiment data and build conversation context lookup."""
+    print("Loading experiment data for conversation context...")
+    return build_context_lookup(load_experiment())
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Verify promise classifications")
+    parser.add_argument('--export', action='store_true',
+                        help="Export current progress to CSV without reviewing")
+    return parser.parse_args()
+
+
+# =====
+# Data loading
+# =====
+def load_experiment():
+    """Load experiment data for conversation context."""
+    file_pairs = []
+    for data_file in sorted(RAW_DIR.glob("*_data.csv")):
+        treatment = 1 if '_t1_' in data_file.name else (2 if '_t2_' in data_file.name else 0)
+        chat_file = data_file.with_name(data_file.name.replace("_data", "_chat"))
+        chat_path = str(chat_file) if chat_file.exists() else None
+        file_pairs.append((str(data_file), chat_path, treatment))
+    return load_experiment_data(file_pairs, name="Verification")
+
+
+def build_context_lookup(experiment) -> dict:
+    """Build lookup: (session, segment, round, group) -> sorted chat messages."""
+    lookup = {}
+    for session_code, session in experiment.sessions.items():
+        for seg_name, segment in session.segments.items():
+            if not seg_name.startswith('supergame'):
+                continue
+            for round_num, round_obj in segment.rounds.items():
+                for group_id, group in round_obj.groups.items():
+                    key = (session_code, seg_name, round_num, group_id)
+                    lookup[key] = sorted(group.chat_messages, key=lambda m: m.timestamp)
+    return lookup
+
+
+# =====
+# Review item construction
+# =====
+def build_review_items(df: pd.DataFrame) -> list:
+    """Flatten CSV rows into individual message review items."""
+    items = []
+    for row_idx, row in df.iterrows():
+        messages = json.loads(row['messages'])
+        classifications = json.loads(row['classifications'])
+        for msg_idx, (msg, cls) in enumerate(zip(messages, classifications)):
+            items.append(build_item(row, row_idx, msg_idx, msg, cls))
+    return items
+
+
+def build_item(row, row_idx: int, msg_idx: int, msg: str, cls: int) -> dict:
+    """Build a single review item from a CSV row and message index."""
+    return {
+        'key': make_key(row, msg_idx),
+        'row_idx': row_idx,
+        'msg_idx': msg_idx,
+        'message': msg,
+        'original_classification': cls,
+        'session_code': row['session_code'],
+        'segment': row['segment'],
+        'round': int(row['round']),
+        'group': int(row['group']),
+        'label': row['label'],
+    }
+
+
+def make_key(row, msg_idx: int) -> str:
+    """Create unique key for a message within a player-round."""
+    return f"{row['session_code']}|{row['segment']}|{row['round']}|{row['group']}|{row['label']}|{msg_idx}"
+
+
+# =====
+# Progress management
+# =====
+def load_progress() -> dict:
+    """Load review progress from JSON file."""
+    if PROGRESS_FILE.exists():
+        return json.loads(PROGRESS_FILE.read_text())
+    return {}
+
+
+def save_progress(progress: dict):
+    """Save review progress to JSON file."""
+    PROGRESS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    PROGRESS_FILE.write_text(json.dumps(progress, indent=2))
+
+
+# =====
+# Interactive review
+# =====
+def run_review(items: list, progress: dict, context_lookup: dict) -> dict:
+    """Run the interactive review loop."""
+    unreviewed = [i for i in items if i['key'] not in progress]
+    total = len(items)
+    done_count = total - len(unreviewed)
+    print(f"\nStarting review. {len(unreviewed)} messages remaining.")
+    print("Controls: [Enter]=Confirm  [f]=Flip  [s]=Skip  [q]=Save & Quit\n")
+
+    for item in unreviewed:
+        done_count += 1
+        display_message(item, done_count, total, context_lookup)
+        done_count, should_quit = process_action(item, progress, done_count, total)
+        if should_quit:
+            return progress
+
+    return finish_review(progress, total, total, complete=True)
+
+
+def process_action(item: dict, progress: dict, done: int, total: int) -> tuple:
+    """Handle a single review action. Returns (done_count, should_quit)."""
+    action = get_user_action(item['original_classification'])
+    if action == 'quit':
+        finish_review(progress, done - 1, total, complete=False)
+        return done, True
+    if action == 'skip':
+        return done - 1, False
+    record_review(progress, item, action)
+    if done % 50 == 0:
+        save_progress(progress)
+    return done, False
+
+
+def record_review(progress: dict, item: dict, verified_cls: int):
+    """Record a single review decision."""
+    progress[item['key']] = {
+        'verified': verified_cls,
+        'original': item['original_classification'],
+        'changed': verified_cls != item['original_classification'],
+    }
+
+
+def finish_review(progress: dict, done: int, total: int, *, complete: bool) -> dict:
+    """Save progress and print completion message."""
+    save_progress(progress)
+    if complete:
+        print(f"\nReview complete! All {total} messages reviewed.")
+    else:
+        print(f"\nProgress saved. {done} of {total} reviewed.")
+    return progress
+
+
+def display_message(item: dict, current: int, total: int, context_lookup: dict):
+    """Display a message with its group conversation context."""
+    print_header(item, current, total)
+    ctx_key = (item['session_code'], item['segment'], item['round'], item['group'])
+    group_msgs = context_lookup.get(ctx_key, [])
+    print_conversation(group_msgs, item)
+    print_label(item['original_classification'])
+
+
+def print_header(item: dict, current: int, total: int):
+    """Print the message header with location info."""
+    print("=" * 70)
+    print(f"  Message {current}/{total}  |  {item['session_code']}  |  "
+          f"{item['segment']}, Round {item['round']}, Group {item['group']}")
+    print("=" * 70)
+
+
+def print_conversation(group_msgs: list, item: dict):
+    """Print the group conversation with the target message highlighted."""
+    target_idx = find_target_index(group_msgs, item['label'], item['msg_idx'])
+    print("\nGroup conversation:")
+    if not group_msgs:
+        print(f"  \033[1;33m► {item['label']}: {item['message']}\033[0m  ◄")
+        return
+    for i, msg in enumerate(group_msgs):
+        if i == target_idx:
+            print(f"  \033[1;33m► {msg.nickname}: {msg.body}\033[0m  ◄")
+        else:
+            print(f"    {msg.nickname}: {msg.body}")
+
+
+def print_label(cls: int):
+    """Print the current classification label."""
+    label = "\033[1;32mPROMISE (1)\033[0m" if cls == 1 else "NOT PROMISE (0)"
+    print(f"\nCurrent label: {label}")
+
+
+def find_target_index(group_msgs: list, label: str, msg_idx: int) -> int | None:
+    """Find the global index of the player's N-th message in the group conversation."""
+    player_count = 0
+    for i, msg in enumerate(group_msgs):
+        if msg.nickname == label:
+            if player_count == msg_idx:
+                return i
+            player_count += 1
+    return None
+
+
+def get_user_action(current_cls: int):
+    """Get user action: returns verified classification (int), 'skip', or 'quit'."""
+    flip_label = "PROMISE (1)" if current_cls == 0 else "NOT PROMISE (0)"
+    try:
+        action = input(f"[Enter] Confirm  [f] Flip→{flip_label}  [s] Skip  [q] Quit > ")
+    except (EOFError, KeyboardInterrupt):
+        return 'quit'
+
+    action = action.strip().lower()
+    if action == 'q':
+        return 'quit'
+    if action == 's':
+        return 'skip'
+    if action == 'f':
+        return 1 - current_cls
+    return current_cls
+
+
+# =====
+# Export results
+# =====
+def export_results(df: pd.DataFrame, progress: dict):
+    """Export verified results to CSV with review status columns."""
+    if not progress:
+        print("\nNo reviews to export.")
+        return
+
+    row_results = [compute_row_verification(row, progress) for _, row in df.iterrows()]
+
+    df_out = df.copy()
+    df_out['verified_classifications'] = [r[0] for r in row_results]
+    df_out['review_status'] = [r[1] for r in row_results]
+    df_out['num_changes'] = [r[2] for r in row_results]
+
+    OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    df_out.to_csv(OUTPUT_FILE, index=False)
+    print_summary(progress)
+    print(f"\nVerified results saved to: {OUTPUT_FILE}")
+
+
+def compute_row_verification(row, progress: dict) -> tuple:
+    """Compute verified classifications and status for a single row."""
+    messages = json.loads(row['messages'])
+    verified = json.loads(row['classifications'])
+    changes, reviewed = 0, 0
+
+    for msg_idx in range(len(messages)):
+        key = make_key(row, msg_idx)
+        if key in progress:
+            verified[msg_idx] = progress[key]['verified']
+            changes += int(progress[key]['changed'])
+            reviewed += 1
+
+    status = 'verified' if reviewed == len(messages) else ('partial' if reviewed > 0 else 'unreviewed')
+    return json.dumps(verified), status, changes
+
+
+def print_summary(progress: dict):
+    """Print agreement statistics."""
+    total = len(progress)
+    changed = sum(1 for p in progress.values() if p['changed'])
+    confirmed = total - changed
+    flipped_to_1 = sum(1 for p in progress.values() if p['changed'] and p['verified'] == 1)
+    flipped_to_0 = sum(1 for p in progress.values() if p['changed'] and p['verified'] == 0)
+
+    print("\n" + "=" * 50)
+    print("VERIFICATION SUMMARY")
+    print("=" * 50)
+    print(f"Messages reviewed:  {total}")
+    print(f"Confirmed (agree):  {confirmed} ({confirmed / max(total, 1) * 100:.1f}%)")
+    print(f"Changed (disagree): {changed} ({changed / max(total, 1) * 100:.1f}%)")
+    print(f"  0→1 (missed promises): {flipped_to_1}")
+    print(f"  1→0 (false promises):  {flipped_to_0}")
+    print("=" * 50)
+
+
+# %%
+if __name__ == "__main__":
+    main()

--- a/analysis/tests/test_verify_promises.py
+++ b/analysis/tests/test_verify_promises.py
@@ -1,0 +1,380 @@
+"""
+Tests for verify_promises.py — interactive promise verification tool.
+
+Author: Claude Code
+Date: 2026-04-10
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "derived"))
+
+from verify_promises import (
+    build_context_lookup,
+    build_item,
+    build_review_items,
+    compute_row_verification,
+    export_results,
+    find_target_index,
+    make_key,
+    print_summary,
+    record_review,
+)
+
+
+# =====
+# Helpers
+# =====
+def make_csv_row(**overrides):
+    """Build a dict mimicking a CSV row for testing."""
+    defaults = {
+        "session_code": "test_session",
+        "treatment": 1,
+        "segment": "supergame1",
+        "round": 2,
+        "group": 1,
+        "label": "A",
+        "participant_id": 1,
+        "contribution": 25.0,
+        "payoff": 40.0,
+        "message_count": 2,
+        "promise_count": 1,
+        "promise_percentage": 50.0,
+        "messages": json.dumps(["I will give 25", "Ok"]),
+        "classifications": json.dumps([1, 0]),
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def make_df(rows=None):
+    """Build a DataFrame from row dicts."""
+    if rows is None:
+        rows = [make_csv_row()]
+    return pd.DataFrame(rows)
+
+
+def make_chat_msg(nickname, body, timestamp=0):
+    """Build a mock ChatMessage."""
+    return MagicMock(nickname=nickname, body=body, timestamp=timestamp)
+
+
+def _mock_experiment(sess_code, seg_name, round_num, group_id, msgs):
+    """Build a minimal experiment mock with one group."""
+    group = MagicMock(chat_messages=msgs)
+    round_obj = MagicMock(groups={group_id: group})
+    segment = MagicMock(rounds={round_num: round_obj})
+    session = MagicMock(segments={seg_name: segment})
+    return MagicMock(sessions={sess_code: session})
+
+
+# =====
+# Test make_key and build_item
+# =====
+class TestKeyAndItem:
+    """Tests for key generation and item construction."""
+
+    def test_produces_pipe_separated_key(self):
+        """Key should contain all identifying fields separated by pipes."""
+        assert make_key(make_csv_row(), 0) == "test_session|supergame1|2|1|A|0"
+
+    def test_different_msg_idx_produces_different_key(self):
+        """Keys should differ for different message indices."""
+        row = make_csv_row()
+        assert make_key(row, 0) != make_key(row, 1)
+
+    def test_different_labels_produce_different_keys(self):
+        """Keys should differ for different player labels."""
+        assert make_key(make_csv_row(label="A"), 0) != make_key(make_csv_row(label="B"), 0)
+
+    def test_item_captures_all_fields(self):
+        """Item should contain key, indices, message, and metadata."""
+        item = build_item(make_csv_row(), row_idx=5, msg_idx=1, msg="Ok", cls=0)
+        assert item["key"] == "test_session|supergame1|2|1|A|1"
+        assert item["row_idx"] == 5
+        assert item["msg_idx"] == 1
+        assert item["message"] == "Ok"
+        assert item["original_classification"] == 0
+
+    def test_round_and_group_are_int(self):
+        """Round and group should be integers for context lookup compatibility."""
+        item = build_item(make_csv_row(round=3, group=2), 0, 0, "msg", 1)
+        assert isinstance(item["round"], int)
+        assert isinstance(item["group"], int)
+
+
+# =====
+# Test build_review_items
+# =====
+class TestBuildReviewItems:
+    """Tests for flattening CSV into review items."""
+
+    def test_single_row_two_messages(self):
+        """Row with 2 messages should produce 2 review items."""
+        df = make_df()
+        items = build_review_items(df)
+        assert len(items) == 2
+
+    def test_preserves_message_order(self):
+        """Items should follow message order within each row."""
+        df = make_df()
+        items = build_review_items(df)
+        assert items[0]["message"] == "I will give 25"
+        assert items[1]["message"] == "Ok"
+
+    def test_multiple_rows(self):
+        """Multiple rows should all be flattened."""
+        rows = [
+            make_csv_row(label="A", messages=json.dumps(["msg1"])),
+            make_csv_row(label="B", messages=json.dumps(["msg2", "msg3"])),
+        ]
+        df = make_df(rows)
+        items = build_review_items(df)
+        assert len(items) == 3
+
+    def test_empty_messages_row(self):
+        """Row with empty messages array should produce 0 items."""
+        rows = [make_csv_row(messages=json.dumps([]), classifications=json.dumps([]))]
+        df = make_df(rows)
+        items = build_review_items(df)
+        assert len(items) == 0
+
+    def test_all_keys_unique(self):
+        """All review item keys must be unique."""
+        rows = [
+            make_csv_row(label="A", messages=json.dumps(["m1", "m2"])),
+            make_csv_row(label="B", messages=json.dumps(["m3"])),
+        ]
+        df = make_df(rows)
+        items = build_review_items(df)
+        keys = [i["key"] for i in items]
+        assert len(keys) == len(set(keys))
+
+
+# =====
+# Test find_target_index
+# =====
+class TestFindTargetIndex:
+    """Tests for finding a player's N-th message in group conversation."""
+
+    def test_finds_first_message(self):
+        """Should return index 0 for player's first message at start."""
+        msgs = [make_chat_msg("A", "Hello", 1), make_chat_msg("B", "Hi", 2)]
+        assert find_target_index(msgs, "A", 0) == 0
+
+    def test_finds_second_message_of_player(self):
+        """Should return correct global index for player's second message."""
+        msgs = [
+            make_chat_msg("A", "Hello", 1),
+            make_chat_msg("B", "Hi", 2),
+            make_chat_msg("A", "How are you?", 3),
+        ]
+        assert find_target_index(msgs, "A", 1) == 2
+
+    def test_returns_none_for_out_of_range(self):
+        """Should return None when msg_idx exceeds player's message count."""
+        msgs = [make_chat_msg("A", "Hello", 1)]
+        assert find_target_index(msgs, "A", 5) is None
+
+    def test_returns_none_for_missing_player(self):
+        """Should return None when player not in conversation."""
+        msgs = [make_chat_msg("A", "Hello", 1)]
+        assert find_target_index(msgs, "C", 0) is None
+
+    def test_returns_none_for_empty_list(self):
+        """Should return None for empty message list."""
+        assert find_target_index([], "A", 0) is None
+
+    def test_multiple_players_interleaved(self):
+        """Should correctly count per-player indices in interleaved messages."""
+        msgs = [
+            make_chat_msg("A", "a1", 1),
+            make_chat_msg("B", "b1", 2),
+            make_chat_msg("C", "c1", 3),
+            make_chat_msg("A", "a2", 4),
+            make_chat_msg("B", "b2", 5),
+        ]
+        assert find_target_index(msgs, "B", 0) == 1
+        assert find_target_index(msgs, "B", 1) == 4
+        assert find_target_index(msgs, "C", 0) == 2
+
+
+# =====
+# Test record_review
+# =====
+class TestRecordReview:
+    """Tests for recording review decisions."""
+
+    def test_records_confirmed_decision(self):
+        """Confirming should store original classification unchanged."""
+        progress = {}
+        item = {"key": "k1", "original_classification": 1}
+        record_review(progress, item, verified_cls=1)
+        assert progress["k1"]["verified"] == 1
+        assert progress["k1"]["original"] == 1
+        assert progress["k1"]["changed"] is False
+
+    def test_records_flipped_decision(self):
+        """Flipping should store new classification and mark changed."""
+        progress = {}
+        item = {"key": "k1", "original_classification": 1}
+        record_review(progress, item, verified_cls=0)
+        assert progress["k1"]["verified"] == 0
+        assert progress["k1"]["original"] == 1
+        assert progress["k1"]["changed"] is True
+
+
+# =====
+# Test compute_row_verification
+# =====
+class TestComputeRowVerification:
+    """Tests for computing verified classifications per CSV row."""
+
+    def test_unreviewed_row(self):
+        """Row with no reviews should return 'unreviewed' status."""
+        row = make_csv_row()
+        cls, status, changes = compute_row_verification(row, {})
+        assert status == "unreviewed"
+        assert changes == 0
+        assert json.loads(cls) == [1, 0]  # unchanged originals
+
+    def test_partially_reviewed_row(self):
+        """Row with some reviews should return 'partial' status."""
+        row = make_csv_row()
+        key_0 = make_key(row, 0)
+        progress = {key_0: {"verified": 0, "original": 1, "changed": True}}
+        cls, status, changes = compute_row_verification(row, progress)
+        assert status == "partial"
+        assert changes == 1
+        assert json.loads(cls) == [0, 0]  # first flipped, second unchanged
+
+    def test_fully_reviewed_row(self):
+        """Row with all reviews should return 'verified' status."""
+        row = make_csv_row()
+        progress = {
+            make_key(row, 0): {"verified": 1, "original": 1, "changed": False},
+            make_key(row, 1): {"verified": 1, "original": 0, "changed": True},
+        }
+        cls, status, changes = compute_row_verification(row, progress)
+        assert status == "verified"
+        assert changes == 1
+        assert json.loads(cls) == [1, 1]
+
+    def test_single_message_row(self):
+        """Row with one message should work correctly."""
+        row = make_csv_row(
+            messages=json.dumps(["single"]),
+            classifications=json.dumps([0]),
+        )
+        key = make_key(row, 0)
+        progress = {key: {"verified": 0, "original": 0, "changed": False}}
+        cls, status, changes = compute_row_verification(row, progress)
+        assert status == "verified"
+        assert changes == 0
+
+
+# =====
+# Test export_results
+# =====
+class TestExportResults:
+    """Tests for CSV export logic."""
+
+    def test_no_export_on_empty_progress(self, capsys):
+        """Should print message and not create file when progress is empty."""
+        df = make_df()
+        export_results(df, {})
+        captured = capsys.readouterr()
+        assert "No reviews to export" in captured.out
+
+    def test_export_creates_correct_columns(self, tmp_path, monkeypatch):
+        """Exported CSV should have verification columns."""
+        output_file = tmp_path / "verified.csv"
+        monkeypatch.setattr(
+            "verify_promises.OUTPUT_FILE", output_file
+        )
+        df = make_df()
+        row = df.iloc[0]
+        key_0 = make_key(row, 0)
+        progress = {key_0: {"verified": 0, "original": 1, "changed": True}}
+
+        export_results(df, progress)
+
+        result = pd.read_csv(output_file)
+        assert "verified_classifications" in result.columns
+        assert "review_status" in result.columns
+        assert "num_changes" in result.columns
+        assert result.iloc[0]["review_status"] == "partial"
+        assert result.iloc[0]["num_changes"] == 1
+
+
+# =====
+# Test build_context_lookup
+# =====
+class TestBuildContextLookup:
+    """Tests for experiment data context lookup construction."""
+
+    def test_builds_lookup_from_experiment(self):
+        """Should create keyed lookup from experiment data."""
+        experiment = _mock_experiment("sess1", "supergame1", 2, 1, [make_chat_msg("A", "Hello", 1.0)])
+        lookup = build_context_lookup(experiment)
+        key = ("sess1", "supergame1", 2, 1)
+        assert key in lookup
+        assert len(lookup[key]) == 1
+        assert lookup[key][0].body == "Hello"
+
+    def test_skips_non_supergame_segments(self):
+        """Should not include introduction or finalresults segments."""
+        seg = MagicMock(rounds={})
+        session = MagicMock(segments={"introduction": seg, "finalresults": seg})
+        experiment = MagicMock(sessions={"sess1": session})
+        assert len(build_context_lookup(experiment)) == 0
+
+    def test_sorts_messages_by_timestamp(self):
+        """Messages in lookup should be sorted by timestamp."""
+        msgs = [make_chat_msg("B", "Second", 2.0), make_chat_msg("A", "First", 1.0)]
+        experiment = _mock_experiment("s1", "supergame2", 1, 1, msgs)
+        result = build_context_lookup(experiment)[("s1", "supergame2", 1, 1)]
+        assert result[0].timestamp < result[1].timestamp
+
+
+# =====
+# Test print_summary
+# =====
+class TestPrintSummary:
+    """Tests for summary statistics output."""
+
+    def test_summary_with_all_confirmed(self, capsys):
+        """Should report 100% agreement when nothing changed."""
+        progress = {
+            "k1": {"verified": 1, "original": 1, "changed": False},
+            "k2": {"verified": 0, "original": 0, "changed": False},
+        }
+        print_summary(progress)
+        out = capsys.readouterr().out
+        assert "Confirmed (agree):  2" in out
+        assert "Changed (disagree): 0" in out
+
+    def test_summary_with_flips(self, capsys):
+        """Should report correct flip counts by direction."""
+        progress = {
+            "k1": {"verified": 1, "original": 0, "changed": True},  # 0->1
+            "k2": {"verified": 0, "original": 1, "changed": True},  # 1->0
+            "k3": {"verified": 1, "original": 1, "changed": False},
+        }
+        print_summary(progress)
+        out = capsys.readouterr().out
+        assert "Changed (disagree): 2" in out
+        assert "0→1 (missed promises): 1" in out  # noqa: RUF001
+        assert "1→0 (false promises):  1" in out  # noqa: RUF001
+
+    def test_summary_handles_empty_progress(self, capsys):
+        """Should not crash on empty progress (division by zero guard)."""
+        print_summary({})
+        out = capsys.readouterr().out
+        assert "Messages reviewed:  0" in out


### PR DESCRIPTION
## Summary
- Adds `analysis/derived/verify_promises.py` — an interactive terminal tool for manually reviewing each LLM-assigned promise classification (0/1) with full group conversation context
- Supports pause/resume via JSON progress file, exports verified CSV with `verified_classifications`, `review_status`, and `num_changes` columns
- Includes 30 unit tests covering key generation, review items, context lookup, and export logic

## Test plan
- [x] Tool loads all 4700 messages from `promise_classifications.csv`
- [x] Group conversation context displays correctly with target message highlighted
- [x] Confirm (Enter), flip (f), skip (s), and quit (q) controls work
- [x] Progress saves to JSON and resumes correctly
- [x] `--export` flag re-exports without entering interactive mode
- [x] Verified CSV has correct `verified_classifications`, `review_status`, `num_changes` columns
- [x] Summary statistics report agreement rate with directional breakdown
- [x] 30 unit tests pass
- [x] Python standards checker passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)